### PR TITLE
Fix assert on the logger

### DIFF
--- a/lib/amqp.js
+++ b/lib/amqp.js
@@ -12,7 +12,7 @@ module.exports = function (config, logger) {
   assert(_.has(config, 'queues') && _.isArray(config.queues), 'Config should have a queues array');
   assert(_.has(config, 'bindings') && _.isArray(config.bindings), 'Config should have a bindings array');
   assert(_.isObject(logger), 'Logger should be an object');
-  assert(_.has(logger, 'error') && _.isFunction(logger.error), 'Logger should have a method error');
+  assert(_.isFunction(logger.error), 'Logger should have a method error');
 
   // create url
   var url = defineUrl(config.connection);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mq-library",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An easy to use library to work with Message Queuing",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
What this PR does / why we need it:

Fix the asserts on the `logger` given in parameters.
The following assertions were made : 
* `logger` must be an object
* `logger` must have a direct property named `error` (via the use of the `_.has` function)
* `error` must be a function

The second assertion can break even if `logger.error` is a function.

For example : 
```
var Object1 = function(){this.error = function(){}};
var Object2 = function(){};
Object2.prototype = new Object1();
var o = new Object2();

_.has(o, 'error');
//false

_.isFunction(o.error);
// true
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #